### PR TITLE
Javascript API: Fix typo which included wrong code for keyboard example

### DIFF
--- a/src/content/community-apis/javascript-sdk.md
+++ b/src/content/community-apis/javascript-sdk.md
@@ -37,7 +37,7 @@ Download and install the text editor of your choice:
 ### Data Streaming
   {{> data-streaming}}
 ### Keyboard
-  {{> roll}}
+  {{> keyboard}}
 ### Roll
   {{> roll}}
 ### Shakeometer


### PR DESCRIPTION
Fix typo in Javascript API document which included wrong code for keyboard example.